### PR TITLE
Implement basic prompt handling loop

### DIFF
--- a/codeorbit/README.md
+++ b/codeorbit/README.md
@@ -108,6 +108,20 @@ cargo fmt
 cargo clippy
 ```
 
+## Prompt Handling Loop
+
+The extension provides a simple round-trip for user prompts. A prompt entered in
+the UI is sent to the orchestrator, which forwards it to the `UiPlannerAgent`.
+The agent returns a UI component plan and the orchestrator delivers this back to
+the prompt panel for display.
+
+Main files involved:
+
+- `ui/prompt_panel.rs` – gathers user input and renders responses.
+- `core/orchestrator.rs` – routes prompts and manages agents.
+- `agents/frontend/ui_planner_agent.rs` – interprets prompts and creates a UI plan.
+
+
 ## Contributing
 
 Contributions are welcome! Please read our [Contributing Guidelines](CONTRIBUTING.md) for details.

--- a/codeorbit/agents/frontend/ui_planner_agent.rs
+++ b/codeorbit/agents/frontend/ui_planner_agent.rs
@@ -71,6 +71,24 @@ impl UiPlannerAgent {
         
         Ok(layout)
     }
+
+    /// Parses a natural language prompt and returns a simple UI plan.
+    pub async fn plan_from_prompt(&self, prompt: &str) -> Result<String> {
+        log::debug!("Planning UI for prompt: {}", prompt);
+
+        // Very naive keyword extraction for demonstration purposes.
+        let mut components = vec!["AppBar".to_string()];
+        let prompt_lower = prompt.to_lowercase();
+        if prompt_lower.contains("login") {
+            components.push("LoginForm".to_string());
+        }
+        if prompt_lower.contains("footer") || !prompt_lower.contains("login") {
+            components.push("Footer".to_string());
+        }
+
+        let plan = serde_json::to_string(&components)?;
+        Ok(plan)
+    }
 }
 
 #[async_trait]
@@ -166,5 +184,12 @@ mod tests {
         let result = agent.process(&request.to_string()).await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), crate::core::error::Error::AgentError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_plan_from_prompt() {
+        let agent = UiPlannerAgent::new();
+        let plan = agent.plan_from_prompt("Login page").await.unwrap();
+        assert!(plan.contains("LoginForm"));
     }
 }

--- a/codeorbit/core/orchestrator.rs
+++ b/codeorbit/core/orchestrator.rs
@@ -3,11 +3,13 @@
 use crate::core::error::Result;
 use crate::core::agent_registry::AgentRegistry;
 use crate::core::context::Context;
+use crate::agents::frontend::ui_planner_agent::UiPlannerAgent;
 
 /// The Orchestrator manages the lifecycle of agents and coordinates their activities.
 pub struct Orchestrator {
     agent_registry: AgentRegistry,
     context: Context,
+    ui_planner: UiPlannerAgent,
 }
 
 impl Orchestrator {
@@ -16,6 +18,7 @@ impl Orchestrator {
         Self {
             agent_registry: AgentRegistry::new(),
             context: Context::new(),
+            ui_planner: UiPlannerAgent::new(),
         }
     }
 
@@ -23,6 +26,7 @@ impl Orchestrator {
     pub async fn initialize(&mut self) -> Result<()> {
         log::info!("Initializing CodeOrbit Orchestrator");
         self.agent_registry.initialize().await?;
+        self.ui_planner.initialize().await?;
         Ok(())
     }
 
@@ -35,10 +39,20 @@ impl Orchestrator {
         Ok("Request processed by CodeOrbit".to_string())
     }
 
+    /// Handles a prompt originating from the UI and returns the agent response.
+    pub async fn handle_user_prompt(&mut self, prompt: &str) -> Result<String> {
+        log::info!("User prompt: {}", prompt);
+
+        // Delegate to the UI planner agent for now.
+        let response = self.ui_planner.plan_from_prompt(prompt).await?;
+        Ok(response)
+    }
+
     /// Shuts down the orchestrator and all agents.
     pub async fn shutdown(&mut self) -> Result<()> {
         log::info!("Shutting down CodeOrbit Orchestrator");
         self.agent_registry.shutdown().await?;
+        self.ui_planner.shutdown().await?;
         Ok(())
     }
 }
@@ -51,5 +65,16 @@ mod tests {
     async fn test_orchestrator_initialization() {
         let mut orchestrator = Orchestrator::new();
         assert!(orchestrator.initialize().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_handle_user_prompt() {
+        let mut orchestrator = Orchestrator::new();
+        orchestrator.initialize().await.unwrap();
+        let response = orchestrator
+            .handle_user_prompt("Create login page")
+            .await
+            .unwrap();
+        assert!(!response.is_empty());
     }
 }

--- a/codeorbit/src/lib.rs
+++ b/codeorbit/src/lib.rs
@@ -59,7 +59,8 @@ impl CodeOrbit {
         cx: &mut ViewContext<Self>,
     ) {
         if self.panel.is_none() {
-            let panel = cx.new_view(|cx| PromptPanel::new(cx));
+            let orchestrator = self.orchestrator.clone();
+            let panel = cx.new_view(move |_cx| PromptPanel::new(orchestrator));
             self.panel = Some(panel);
         } else {
             self.panel = None;

--- a/codeorbit/ui/prompt_panel.rs
+++ b/codeorbit/ui/prompt_panel.rs
@@ -5,21 +5,26 @@
 
 use gpui::*;
 use crate::core::Result;
+use crate::core::Orchestrator;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 /// The main prompt panel component.
 pub struct PromptPanel {
     input: String,
     output: String,
     is_visible: bool,
+    orchestrator: Arc<Mutex<Orchestrator>>,
 }
 
 impl PromptPanel {
     /// Creates a new instance of the prompt panel.
-    pub fn new() -> Self {
+    pub fn new(orchestrator: Arc<Mutex<Orchestrator>>) -> Self {
         Self {
             input: String::new(),
             output: String::new(),
             is_visible: false,
+            orchestrator,
         }
     }
 
@@ -41,8 +46,41 @@ impl PromptPanel {
     /// Handles user input.
     pub fn handle_input(&mut self, input: &str) -> Result<()> {
         self.input = input.to_string();
-        // TODO: Process the input through the orchestrator
+        // Input is stored until submitted
         Ok(())
+    }
+
+    /// Sends the current prompt to the orchestrator and updates the output.
+    pub fn submit(&mut self, cx: &mut Context<Self>) {
+        let prompt = self.input.trim().to_string();
+        if prompt.is_empty() {
+            return;
+        }
+
+        self.input.clear();
+        let orchestrator = self.orchestrator.clone();
+        cx.spawn(async move |handle, cx| {
+            match orchestrator.lock().await.handle_user_prompt(&prompt).await {
+                Ok(resp) => {
+                    if let Ok(panel) = handle.upgrade(cx) {
+                        panel.update(cx, |panel, cx| {
+                            panel.update_output(&resp);
+                            cx.notify();
+                        }).ok();
+                    }
+                }
+                Err(e) => {
+                    if let Ok(panel) = handle.upgrade(cx) {
+                        panel.update(cx, |panel, cx| {
+                            panel.update_output(&format!("Error: {}", e));
+                            cx.notify();
+                        }).ok();
+                    }
+                }
+            }
+            Ok(())
+        }).detach_and_log_err(cx);
+        cx.notify();
     }
 
     /// Updates the output display.
@@ -87,10 +125,22 @@ impl PromptPanel {
                             .rounded()
                             .placeholder("Ask CodeOrbit...")
                             .value(&self.input)
-                            .on_input(move |_, input, cx| {
-                                // TODO: Handle input
+                            .on_input(cx.listener(|this, input: SharedString, _, cx| {
+                                this.handle_input(&input).ok();
                                 cx.notify();
-                            })
+                            }))
+                    )
+                    .child(
+                        div()
+                            .mt_2()
+                            .bg(rgba(0.3, 0.3, 0.3, 1.0))
+                            .rounded()
+                            .p_2()
+                            .cursor_pointer()
+                            .child("Send")
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.submit(cx);
+                            }))
                     )
             )
     }
@@ -100,10 +150,13 @@ impl PromptPanel {
 mod tests {
     use super::*;
     use gpui::TestAppContext;
+    use crate::core::Orchestrator;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
 
     #[test]
     fn test_prompt_panel_visibility() {
-        let mut panel = PromptPanel::new();
+        let mut panel = PromptPanel::new(Arc::new(Mutex::new(Orchestrator::new())));
         assert!(!panel.is_visible);
         
         panel.show();
@@ -121,7 +174,7 @@ mod tests {
     
     #[test]
     fn test_handle_input() {
-        let mut panel = PromptPanel::new();
+        let mut panel = PromptPanel::new(Arc::new(Mutex::new(Orchestrator::new())));
         let input = "Test input";
         
         assert_eq!(panel.input, "");
@@ -131,7 +184,7 @@ mod tests {
     
     #[test]
     fn test_update_output() {
-        let mut panel = PromptPanel::new();
+        let mut panel = PromptPanel::new(Arc::new(Mutex::new(Orchestrator::new())));
         let output = "Test output";
         
         assert_eq!(panel.output, "");


### PR DESCRIPTION
## Summary
- wire prompt panel to orchestrator using async spawn
- add orchestrator method to route prompts to the UI planner agent
- implement simple `plan_from_prompt` for generating UI component lists
- pass orchestrator handle when creating `PromptPanel`
- document the round trip in README

## Testing
- `cargo fmt`
- `cargo test` *(fails: failed to fetch dependency due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6842c97a4400832586f7a4c9292801fc